### PR TITLE
feat: add delay on init for *arr setup

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -75,7 +75,13 @@ class Api(object):
                 self.__create(resource, body)
 
     def initialize(self):
-        response = self.r.get('{}/initialize.js'.format(self.__url()))
+        url = '{}/initialize.js'.format(self.__url())
+        response = self.r.get(url)
+        status_code = response.status_code
+
+        while response.status_code >= 300:
+            sleep(10)
+            response = self.r.get(url)
 
         bits = response.text.split("'")
         api_root = bits[1]


### PR DESCRIPTION
This implementes a delay at the start for when *arr programs are still starting so that on slower machines it will only run once there is a 200 status returned.