### PR TITLE
feat: Support Sonarr v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,29 +1,41 @@
 name: docker
 on:
+  workflow_dispatch:
   push:
-    workflow_dispatch:
     branches:
-      - 'master'
+      - "master"
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
+      DOCKER_TOKEN: ${{ secrets.DOCKERHUB_TOKEN || github.token }}
+      DOCKER_REGISTRY: ${{ secrets.DOCKERHUB_USERNAME == '' && 'ghcr.io' || 'docker.io'  }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+      - name: Output Docker Repo
+        run: |
+          echo "DOCKER_REPO=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64, linux/arm64, linux/arm/v7
           push: true
-          tags: pierremesure/flemmarr:latest
+          tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:alpine3.19
 
 ENV PYTHONUNBUFFERED=1
 

--- a/src/api.py
+++ b/src/api.py
@@ -75,11 +75,12 @@ class Api(object):
                 self.__create(resource, body)
 
     def initialize(self):
-        response = self.r.get('{}/initialize.js'.format(self.__url()))
+        response = self.r.get('{}/initialize.json'.format(self.__url()))
 
-        bits = response.text.split("'")
-        api_root = bits[1]
-        api_key = bits[3]
+        response_data = response.json()
+        
+        api_root = response_data["apiRoot"]
+        api_key = response_data["apiKey"]
 
         self.path = api_root
         self.r.headers.update({'X-Api-Key': api_key})

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-PyYAML==6.0
-requests==2.28.1
-urllib3==1.26.10
+PyYAML==6.0.1
+requests==2.31.0
+urllib3==2.1.0


### PR DESCRIPTION
# Description

Updates the API to call the `initialize.json` endpoint. Deserializes the response to json and retrieves the `apiKey` and `apiRoot`.

This also refactors the github actions in a contributor friendly way. The workflow should still push to dockerhub, but will opt into pushing to ghcr.io for forks.

# Issues

- Closes #15